### PR TITLE
fix: configure pnpm store before setup-node cache

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -21,18 +21,20 @@ runs:
       with:
         version: ${{ inputs.pnpm-version }}
         run_install: false
+    - name: Configure pnpm store path
+      shell: bash
+      run: |
+        echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "$GITHUB_ENV"
+        echo "${HOME}/.local/share/pnpm" >> "$GITHUB_PATH"
+        STORE_PATH="${HOME}/.pnpm-store"
+        if [ -n "${PNPM_CACHE_FOLDER:-}" ]; then
+          STORE_PATH="${GITHUB_WORKSPACE}/${PNPM_CACHE_FOLDER}"
+        fi
+        mkdir -p "${STORE_PATH}"
+        pnpm config set store-dir "${STORE_PATH}"
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
-    - name: Configure pnpm store path
-      shell: bash
-      run: |
-        echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "$GITHUB_ENV"
-        echo "${HOME}/.local/share/pnpm" >> "$GITHUB_PATH"
-        if [ -n "${PNPM_CACHE_FOLDER:-}" ]; then
-          mkdir -p "${GITHUB_WORKSPACE}/${PNPM_CACHE_FOLDER}"
-          pnpm config set store-dir "${GITHUB_WORKSPACE}/${PNPM_CACHE_FOLDER}"
-        fi


### PR DESCRIPTION
## Summary
- configure the pnpm store path before invoking `actions/setup-node` so the cache path exists during detection
- ensure the configured store directory is created and default to `~/.pnpm-store` when no custom cache folder is supplied

## Testing
- pnpm install

------
https://chatgpt.com/codex/tasks/task_b_690390962cac83268618cef78cf93f3a