### PR TITLE
ci: ensure security scan fetches full git history

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup Node and pnpm
         uses: ./.github/actions/setup-node-pnpm


### PR DESCRIPTION
## Summary
- configure the security scan workflow checkout step to fetch the complete git history

## Testing
- /tmp/gitleaks detect --no-banner --source . --verbose --redact --report-format sarif --report-path gitleaks.sarif

------
https://chatgpt.com/codex/tasks/task_b_6903930295bc8326a7e505ec8a55a883