### PR TITLE
chore(renovate): group deps by ecosystem

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,109 +10,103 @@
     "group:recommended",
     "helpers:pinGitHubActionDigests"
   ],
-  "enabledManagers": [
-    "npm",
-    "dockerfile",
-    "github-actions"
-  ],
+  "enabledManagers": ["npm", "dockerfile", "github-actions"],
   "rangeStrategy": "bump",
   "dependencyDashboard": true,
   "osvVulnerabilityAlerts": true,
   "prHourlyLimit": 4,
   "prConcurrentLimit": 10,
-  "schedule": [
-    "after 9am on saturday",
-    "before 10pm on sunday"
-  ],
+  "schedule": ["after 9am on saturday", "before 10pm on sunday"],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,
-    "schedule": [
-      "after 10pm on sunday"
-    ]
+    "schedule": ["after 10pm on sunday"]
   },
   "npm": {
     "enabled": true,
-    "postUpdateOptions": [
-      "pnpmDedupe"
-    ]
+    "postUpdateOptions": ["pnpmDedupe"]
   },
   "packageRules": [
     {
-      "matchManagers": [
-        "npm"
-      ],
-      "matchDepTypes": [
-        "devDependencies"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
-      "labels": [
-        "deps",
-        "automerge"
-      ]
+      "labels": ["deps", "automerge"]
     },
     {
-      "matchManagers": [
-        "npm"
-      ],
-      "matchPackagePatterns": [
-        "@types/*",
-        "eslint*",
-        "biome*"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["@types/*", "eslint*", "biome*"],
+      "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
-      "labels": [
-        "deps",
-        "automerge"
-      ]
+      "labels": ["deps", "automerge"]
     },
     {
-      "matchManagers": [
-        "npm"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["major"],
       "prCreation": "immediate",
       "automerge": false,
-      "labels": [
-        "deps",
-        "major"
-      ]
+      "labels": ["deps", "major"]
     },
     {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "automerge": true
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "groupName": "github-actions",
+      "labels": ["deps", "ci"]
     },
     {
-      "matchManagers": [
-        "dockerfile"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["minor", "patch"],
       "automerge": false
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "stripe",
+        "@stripe/stripe-js",
+        "resend",
+        "streamdown",
+        "s3mini",
+        "drizzle-orm",
+        "dotenv",
+        "postgres"
+      ],
+      "groupName": "core-services",
+      "labels": ["deps", "core-services"]
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "next",
+        "@next/third-parties",
+        "next-intl",
+        "lucide-react",
+        "fumadocs-core",
+        "fumadocs-ui",
+        "embla-carousel-react",
+        "nuqs",
+        "react-hook-form",
+        "motion",
+        "tw-animate-css",
+        "tailwindcss-animate",
+        "react-day-picker",
+        "@tanstack/react-query",
+        "@tanstack/react-query-devtools"
+      ],
+      "groupName": "frontend-experience",
+      "labels": ["deps", "frontend"]
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^tailwind", "@tailwindcss/*"],
+      "groupName": "tailwind-css",
+      "separateMinorPatch": true,
+      "labels": ["deps", "tailwind"]
     }
   ],
   "vulnerabilityAlerts": {
     "assignees": [],
-    "labels": [
-      "security"
-    ]
+    "labels": ["security"]
   }
 }


### PR DESCRIPTION
## 概要
- 新增 github-actions、core-services、frontend-experience 等分组，集中同类依赖的升级
- 为 Tailwind 相关包启用 separateMinorPatch，保留专门 PR 以便迁移
- 对 GitHub Actions 自动标记 deps/ci 标签，便于筛选与自动合并

## 验证
- pnpm lint
