### PR TITLE
chore: regenerate pnpm lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10595,8 +10595,6 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  safer-buffer@2.1.2: {}
-
   scheduler@0.25.0: {}
 
   scroll-into-view-if-needed@3.1.0:


### PR DESCRIPTION
## 概要
- 重新生成 pnpm-lock.yaml，移除重複鍵 safer-buffer@2.1.2，避免 CI 在 frozen 安裝時爆錯

## 驗證
- pnpm install
- pnpm install --frozen-lockfile
- pnpm build
