### PR TITLE
Fix CI test step when using Vitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,13 +85,12 @@ jobs:
           set -uo pipefail
           if node -e "const pkg=require('./package.json'); process.exit(pkg.scripts && pkg.scripts.test ? 0 : 1)"; then
             echo "has_tests=true" >> "$GITHUB_OUTPUT"
-            pnpm test -- --runInBand
-            status=$?
-            if [ "$status" -ne 0 ]; then
+            if pnpm test -- --runInBand; then
+              exit 0
+            else
               pnpm test
-              status=$?
+              exit $?
             fi
-            exit "$status"
           else
             echo "No test script configured, skipping."
             echo "has_tests=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- update the CI workflow test step to retry without the unsupported `--runInBand` flag when it fails

## Testing
- not run (workflow change)

------
https://chatgpt.com/codex/tasks/task_b_690ae02e495c8326ab9b78a076701592