### PR TITLE
fix: grant checks permission for publish unit test action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 defaults:
   run:


### PR DESCRIPTION
## Summary
- grant the CI workflow permission to write check runs so the publish-unit-test-result action can read and update check information

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_690ae40182e88326b14910f8434857e1