### PR TITLE
fix: validate better-auth sessions in middleware

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -46,7 +46,29 @@ export default async function middleware(req: NextRequest) {
     }
   }
 
-  const isLoggedIn = hasBetterAuthSessionCookie(req.cookies.getAll());
+  let isLoggedIn = false;
+
+  if (hasBetterAuthSessionCookie(req.cookies.getAll())) {
+    try {
+      const sessionResponse = await fetch(
+        new URL('/api/auth/get-session', nextUrl),
+        {
+          headers: {
+            cookie: req.headers.get('cookie') ?? '',
+          },
+          cache: 'no-store',
+        }
+      );
+
+      if (sessionResponse.ok) {
+        const sessionData = await sessionResponse.json();
+        isLoggedIn = Boolean(sessionData?.data?.session);
+      }
+    } catch {
+      isLoggedIn = false;
+    }
+  }
+
   const pathnameWithoutLocale = getPathnameWithoutLocale(nextUrl.pathname);
   const routeDecision = evaluateRouteAccess(isLoggedIn, pathnameWithoutLocale);
 


### PR DESCRIPTION
## Summary
- verify middleware sessions by validating the better-auth cookie against /api/auth/get-session
- fall back to treating users as unauthenticated when session validation fails to avoid bypasses

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_690ae3b17ef88326839e439abce84303