### PR TITLE
chore: add credits-gateway decoupling plan

### DIFF
--- a/.codex/plan/credits-gateway-decoupling.md
+++ b/.codex/plan/credits-gateway-decoupling.md
@@ -1,0 +1,12 @@
+# CreditsGateway Abstraction
+
+## 背景
+目前 `src/credits/services/credits-gateway.ts` 暴露 `DbExecutor`（数据访问层细节），导致上层依赖具体仓储类型并破坏接口抽象。
+
+## 目标
+- 引入中立的事务上下文类型或回调机制，使 CreditsGateway 不再依赖仓储实现，同时保持事务支持。
+
+## 任务
+1. 设计新的事务接口（如 `TransactionContext` 或 `runInTransaction` 回调），更新 CreditsGateway 定义及 CreditLedgerService 实现。
+2. 调整使用方（Webhook handler、tests）以新接口交互。
+3. 更新相关测试与文档，验证 `npx tsc --noEmit`、`pnpm test`。


### PR DESCRIPTION
问题背景：CreditsGateway 原本直接暴露 DbExecutor 类型，调用方需要依赖底层 Drizzle 事务实现，破坏接口抽象且不利于第三方实现。
主要改动：
新增 CreditsTransaction 抽象（src/credits/services/transaction-context.ts），作为事务上下文的中立封装。
CreditsGateway 接口及 credit-ledger-service 改为接受 CreditsTransaction，内部通过 resolveExecutor 拿到实际执行器。
Webhook 处理与相关测试更新，使用 createCreditsTransaction(tx) 将现有 payment 事务传递到积分网关。
验证：npx tsc --noEmit、pnpm test -- src/payment/services/__tests__/stripe-payment-service.test.ts。
收益：接口层不再依赖具体数据层类型，可保持事务能力，同时降低未来替换实现或对外暴露接口的风险。